### PR TITLE
Fix: Corrected array update example in section 6 (arr[3] = 100)

### DIFF
--- a/01.Introduction to Data Structures/Arrays/Arrays.md
+++ b/01.Introduction to Data Structures/Arrays/Arrays.md
@@ -236,7 +236,7 @@ Check:
 **Description:** Change the value at a specific index.
 
 ```cpp
-arr = 100;  // Set element at index 3 to 100
+arr[3]= 100;  // Set element at index 3 to 100
 ```
 
 - **Time Complexity:** $O(1)$
@@ -250,11 +250,10 @@ arr = 100;  // Set element at index 3 to 100
 
 #### **Representation**
 
-Before update:
-``
+Before update:{10, 20, 30, 40, 50}
 
-After update:
-``
+
+After update:{10, 20, 30, 100, 50}
 
 ***
 


### PR DESCRIPTION
This PR fixes an incorrect example in the “Updating Elements” section of the notes. Previously, the code showed:

arr = 100;  //  Invalid array update


This was misleading because you cannot assign directly to an array.

Changes Made

Corrected the example to:

arr[3] = 100;  //  Update element at index 3


Updated step-by-step explanation to clarify direct access by index.

Added clear Before/After representation of the array.